### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "description": "A Webpack loader that logs source to your console for debugging purposes.",
   "homepage": "https://github.com/ianwalter/debug-loader",
-  "repository": "ianwalter/debug-loader",
+  "repository" : {
+    "type" : "git",
+    "url" : "git@github.com:ianwalter/debug-loader.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "A Webpack loader that logs source to your console for debugging purposes.",
   "homepage": "https://github.com/ianwalter/debug-loader",
+  "repository": "ianwalter/debug-loader",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Right now https://npm.im/debug-loader does not link to this repo. With this addition to `package.json` it will.